### PR TITLE
Fix Typescript Linting Error

### DIFF
--- a/packages/solid-a11y/package.json
+++ b/packages/solid-a11y/package.json
@@ -22,6 +22,7 @@
   "publishConfig": {
     "exports": {
       ".": {
+        "types": "./types/index.d.ts",
         "import": "./dist/solid-a11y.es.js",
         "require": "./dist/solid-a11y.umd.js"
       }


### PR DESCRIPTION
Help Typescript detect types and lint.

```
> tsc -p ./tsconfig.json

Using TypeScript compiler version 5.5.2 from /Users/forge/code/st1/node_modules/typescript/lib/typescript.js
src/pages/Maps/Create.tsx:28:8 - error TS7016: Could not find a declaration file for module 'solid-a11y'. '/Users/forge/code/solid-simple-tactics/node_modules/.pnpm/solid-a11y@0.5.0_solid-js@1.8.17/node_modules/solid-a11y/dist/solid-a11y.es.js' implicitly has an 'any' type.
  There are types at '/Users/forge/code/st1/node_modules/solid-a11y/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'solid-a11y' library may need to update its package.json or typings.

28 } from "solid-a11y"
```

https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts